### PR TITLE
Fix builders wand vertical mode localization making no sense

### DIFF
--- a/src/main/resources/assets/betterbuilderswands/lang/en_US.lang
+++ b/src/main/resources/assets/betterbuilderswands/lang/en_US.lang
@@ -20,7 +20,7 @@ bbw.chat.mode.verticalnorthsouth=Mode: North-South (+ Vertical) - Extend north, 
 bbw.chat.mode.eastwest=Mode: East-West - Extend east and west from the initial block. No building on east/west face
 bbw.chat.mode.verticaleastwest=Mode: East-West (+ Vertical) - Extend east, west, up and down from the original block. No building on east/west face
 bbw.chat.mode.horizontal=Mode: Horizontal - Extend left and right from the original block. No building on top/bottom face.
-bbw.chat.mode.vertical= Mode: Vertical - Extend up and down from the original block. No building on top/bottom face
+bbw.chat.mode.vertical=Mode: Vertical - Extend up and down from the original block. No building on north/east/south/west face.
 bbw.chat.mode.nolock=Mode: No Lock - Extend left, right, up and down from the original block.
 
 bbw.hover.fluidmode.stopat=Fluid: Stop

--- a/src/main/resources/assets/betterbuilderswands/lang/tr_tr.lang
+++ b/src/main/resources/assets/betterbuilderswands/lang/tr_tr.lang
@@ -20,7 +20,7 @@ bbw.chat.mode.verticalnorthsouth=Mode: North-South (+ Vertical) - Extend north, 
 bbw.chat.mode.eastwest=Mode: East-West - Extend east and west from the initial block. No building on east/west face
 bbw.chat.mode.verticaleastwest=Mode: East-West (+ Vertical) - Extend east, west, up and down from the original block. No building on east/west face
 bbw.chat.mode.horizontal=Mode: Horizontal - Extend left and right from the original block. No building on top/bottom face.
-bbw.chat.mode.vertical= Mode: Vertical - Extend up and down from the original block. No building on top/bottom face
+bbw.chat.mode.vertical=Mode: Vertical - Extend up and down from the original block. No building on north/east/south/west face.
 bbw.chat.mode.nolock=Mode: No Lock - Extend left, right, up and down from the original block.
 
 bbw.hover.fluidmode.stopat=SÄ±vÄ±: Durdur


### PR DESCRIPTION
Removed leading space and updated the text so it actually makes sense.