### PR TITLE
Fix block highlight looking laggy

### DIFF
--- a/src/main/java/portablejim/bbw/core/BlockEvents.java
+++ b/src/main/java/portablejim/bbw/core/BlockEvents.java
@@ -68,11 +68,14 @@ public class BlockEvents {
                             AxisAlignedBB boundingBox = AxisAlignedBB
                                     .getBoundingBox(block.x, block.y, block.z, block.x + 1, block.y + 1, block.z + 1)
                                     .contract(0.005, 0.005, 0.005);
+                            double interpolatedX = event.player.lastTickPosX
+                                    + (event.player.posX - event.player.lastTickPosX) * event.partialTicks;
+                            double interpolatedY = event.player.lastTickPosY
+                                    + (event.player.posY - event.player.lastTickPosY) * event.partialTicks;
+                            double interpolatedZ = event.player.lastTickPosZ
+                                    + (event.player.posZ - event.player.lastTickPosZ) * event.partialTicks;
                             RenderGlobal.drawOutlinedBoundingBox(
-                                    boundingBox.getOffsetBoundingBox(
-                                            -event.player.posX,
-                                            -event.player.posY,
-                                            -event.player.posZ),
+                                    boundingBox.getOffsetBoundingBox(-interpolatedX, -interpolatedY, -interpolatedZ),
                                     0xC0C0C0);
                         }
                         GL11.glEnable(GL11.GL_TEXTURE_2D);


### PR DESCRIPTION
The block highlight was using the real player position (tick based) instead of the current interpolated position of the camera (frame based). This made it look very laggy and bad when moving around.  
This is now fixed by interpolating with `partialTicks`

Before:

https://github.com/GTNewHorizons/BetterBuildersWands/assets/29953391/3f90659b-7c25-43b3-9f61-e7138c5d7c23


After:

https://github.com/GTNewHorizons/BetterBuildersWands/assets/29953391/9dc65f81-51a0-49f8-b451-2cdff6541676

