### PR TITLE
Allow blocks to be nbt sensitive if they are marked as such by a CustomMapping

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,4 +4,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Botania:1.11.1-GTNH:api") {
         transitive = false
     }
+    compileOnly("com.github.GTNewHorizons:ArchitectureCraft:1.10.2") {
+        transitive = false
+    }
 }

--- a/src/main/java/portablejim/bbw/BetterBuildersWandsMod.java
+++ b/src/main/java/portablejim/bbw/BetterBuildersWandsMod.java
@@ -180,7 +180,7 @@ public class BetterBuildersWandsMod {
         GameRegistry.addRecipe(new ShapelessRecipes(newWand(14), Arrays.asList(newWand(13), newWand(13))));
 
         if (Loader.isModLoaded("ArchitectureCraft")) {
-            mappingManager.setMapping(new ArchitectureCraftCustomMapping());
+            ArchitectureCraftCustomMapping.register();
         }
     }
 

--- a/src/main/java/portablejim/bbw/BetterBuildersWandsMod.java
+++ b/src/main/java/portablejim/bbw/BetterBuildersWandsMod.java
@@ -24,6 +24,7 @@ import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
+import portablejim.bbw.compat.architecturecraft.ArchitectureCraftCustomMapping;
 import portablejim.bbw.core.ConfigValues;
 import portablejim.bbw.core.OopsCommand;
 import portablejim.bbw.core.conversion.CustomMappingManager;
@@ -109,7 +110,6 @@ public class BetterBuildersWandsMod {
         mappingManager = new CustomMappingManager();
 
         mappingManager.loadConfig(configValues.OVERRIDES_RECIPES);
-
         /*
          * mappingManager.setMapping(new CustomMapping(Blocks.lapis_ore, 0, new ItemStack(Blocks.lapis_ore, 1, 4),
          * Blocks.lapis_ore, 0)); mappingManager.setMapping(new CustomMapping(Blocks.lit_redstone_ore, 0, new
@@ -178,6 +178,10 @@ public class BetterBuildersWandsMod {
         itemUnbreakableWand.addSubMeta(14);
         GameRegistry.addRecipe(new ShapelessRecipes(newWand(13), Arrays.asList(newWand(12), newWand(12))));
         GameRegistry.addRecipe(new ShapelessRecipes(newWand(14), Arrays.asList(newWand(13), newWand(13))));
+
+        if (Loader.isModLoaded("ArchitectureCraft")) {
+            mappingManager.setMapping(new ArchitectureCraftCustomMapping());
+        }
     }
 
     @EventHandler

--- a/src/main/java/portablejim/bbw/compat/architecturecraft/ArchitectureCraftCustomMapping.java
+++ b/src/main/java/portablejim/bbw/compat/architecturecraft/ArchitectureCraftCustomMapping.java
@@ -1,0 +1,31 @@
+package portablejim.bbw.compat.architecturecraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import gcewing.architecture.common.tile.TileShape;
+import portablejim.bbw.basics.Point3d;
+import portablejim.bbw.core.conversion.CustomMapping;
+import portablejim.bbw.shims.IWorldShim;
+
+public class ArchitectureCraftCustomMapping extends CustomMapping {
+
+    private static final Block SHAPE_BLOCK = GameRegistry.findBlock("ArchitectureCraft", "shape");
+
+    public ArchitectureCraftCustomMapping() {
+        super(SHAPE_BLOCK, 0, new ItemStack(Item.getItemFromBlock(SHAPE_BLOCK)), SHAPE_BLOCK, 0, true);
+    }
+
+    @Override
+    public ItemStack getItems(IWorldShim world, Point3d point) {
+        TileEntity tileEntity = world.getWorld().getTileEntity(point.x, point.y, point.z);
+        if (tileEntity instanceof TileShape) {
+            TileShape shapeTile = ((TileShape) tileEntity);
+            return shapeTile.newItemStack(1);
+        }
+        return super.getItems(world, point);
+    }
+}

--- a/src/main/java/portablejim/bbw/compat/architecturecraft/ArchitectureCraftCustomMapping.java
+++ b/src/main/java/portablejim/bbw/compat/architecturecraft/ArchitectureCraftCustomMapping.java
@@ -7,6 +7,7 @@ import net.minecraft.tileentity.TileEntity;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import gcewing.architecture.common.tile.TileShape;
+import portablejim.bbw.BetterBuildersWandsMod;
 import portablejim.bbw.basics.Point3d;
 import portablejim.bbw.core.conversion.CustomMapping;
 import portablejim.bbw.shims.IWorldShim;
@@ -14,9 +15,10 @@ import portablejim.bbw.shims.IWorldShim;
 public class ArchitectureCraftCustomMapping extends CustomMapping {
 
     private static final Block SHAPE_BLOCK = GameRegistry.findBlock("ArchitectureCraft", "shape");
+    private static final Block GLOWING_SHAPE_BLOCK = GameRegistry.findBlock("ArchitectureCraft", "shapeSE");
 
-    public ArchitectureCraftCustomMapping() {
-        super(SHAPE_BLOCK, 0, new ItemStack(Item.getItemFromBlock(SHAPE_BLOCK)), SHAPE_BLOCK, 0, true);
+    public ArchitectureCraftCustomMapping(Block shapeBlock, int metadata) {
+        super(shapeBlock, metadata, new ItemStack(Item.getItemFromBlock(shapeBlock)), shapeBlock, metadata, true);
     }
 
     @Override
@@ -24,8 +26,18 @@ public class ArchitectureCraftCustomMapping extends CustomMapping {
         TileEntity tileEntity = world.getWorld().getTileEntity(point.x, point.y, point.z);
         if (tileEntity instanceof TileShape) {
             TileShape shapeTile = ((TileShape) tileEntity);
-            return shapeTile.newItemStack(1);
+            ItemStack itemStack = shapeTile.newItemStack(1);
+            itemStack.setItemDamage(getMeta());
+            return itemStack;
         }
         return super.getItems(world, point);
+    }
+
+    public static void register() {
+        BetterBuildersWandsMod.instance.mappingManager.setMapping(new ArchitectureCraftCustomMapping(SHAPE_BLOCK, 0));
+        if (GLOWING_SHAPE_BLOCK != null) {
+            BetterBuildersWandsMod.instance.mappingManager
+                    .setMapping(new ArchitectureCraftCustomMapping(GLOWING_SHAPE_BLOCK, 15));
+        }
     }
 }

--- a/src/main/java/portablejim/bbw/core/BlockEvents.java
+++ b/src/main/java/portablejim/bbw/core/BlockEvents.java
@@ -2,6 +2,7 @@ package portablejim.bbw.core;
 
 import java.util.LinkedList;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -13,7 +14,9 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import portablejim.bbw.BetterBuildersWandsMod;
 import portablejim.bbw.basics.Point3d;
+import portablejim.bbw.core.conversion.CustomMapping;
 import portablejim.bbw.core.items.IWandItem;
 import portablejim.bbw.core.wands.IWand;
 import portablejim.bbw.shims.BasicPlayerShim;
@@ -50,7 +53,15 @@ public class BlockEvents {
                 ItemStack sourceItems = worker.getProperItemStack(worldShim, playerShim, clickedPos);
 
                 if (sourceItems != null && sourceItems.getItem() instanceof ItemBlock) {
-                    int numBlocks = Math.min(wand.getMaxBlocks(event.currentItem), playerShim.countItems(sourceItems));
+                    Block targetedBlock = worldShim.getBlock(clickedPos);
+                    int meta = worldShim.getMetadata(clickedPos);
+                    CustomMapping customMapping = BetterBuildersWandsMod.instance.mappingManager
+                            .getMapping(targetedBlock, meta);
+                    int numBlocks = Math.min(
+                            wand.getMaxBlocks(event.currentItem),
+                            playerShim.countItems(
+                                    sourceItems,
+                                    customMapping != null && customMapping.shouldCopyTileNBT()));
 
                     LinkedList<Point3d> blocks = worker.getBlockPositionList(
                             clickedPos,
@@ -58,7 +69,8 @@ public class BlockEvents {
                             numBlocks,
                             wandItem.getMode(event.currentItem),
                             wandItem.getFaceLock(event.currentItem),
-                            wandItem.getFluidMode(event.currentItem));
+                            wandItem.getFluidMode(event.currentItem),
+                            customMapping != null && customMapping.shouldCopyTileNBT());
                     if (blocks.size() > 0) {
                         GL11.glDisable(GL11.GL_TEXTURE_2D);
                         GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -9,6 +9,8 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.IFluidBlock;
@@ -44,10 +46,14 @@ public class WandWorker {
     public ItemStack getProperItemStack(IWorldShim world, IPlayerShim player, Point3d blockPos) {
         Block block = world.getBlock(blockPos);
         int meta = world.getMetadata(blockPos);
+        CustomMapping customMapping = BetterBuildersWandsMod.instance.mappingManager.getMapping(block, meta);
+        if (customMapping != null) {
+            return customMapping.getItems(world, blockPos);
+        }
         String blockString = String.format("%s/%s", Block.blockRegistry.getNameForObject(block), meta);
         if (!BetterBuildersWandsMod.instance.configValues.HARD_BLACKLIST_SET.contains(blockString)) {
             ItemStack exactItemstack = new ItemStack(block, 1, meta);
-            if (Item.getItemFromBlock(block) != null && player.countItems(exactItemstack) > 0) {
+            if (Item.getItemFromBlock(block) != null && player.countItems(exactItemstack, false) > 0) {
                 return exactItemstack;
             }
             return getEquivalentItemStack(blockPos);
@@ -60,30 +66,23 @@ public class WandWorker {
         int meta = world.getMetadata(blockPos);
         // ArrayList<ItemStack> items = new ArrayList<ItemStack>();
         ItemStack stack = null;
-        CustomMapping customMapping = BetterBuildersWandsMod.instance.mappingManager.getMapping(block, meta);
         String blockString = String.format("%s/%s", Block.blockRegistry.getNameForObject(block), meta);
-        if (customMapping != null) {
-            stack = customMapping.getItems();
-        } else
-            if (block.canSilkHarvest(world.getWorld(), player.getPlayer(), blockPos.x, blockPos.y, blockPos.z, meta)) {
-                stack = BetterBuildersWandsMod.instance.blockCache.getStackedBlock(world, blockPos);
-            } else if (!BetterBuildersWandsMod.instance.configValues.SOFT_BLACKLIST_SET.contains(blockString)) {
-                Item dropped = block.getItemDropped(meta, new Random(), 0);
-                if (dropped != null) {
-                    stack = new ItemStack(
-                            dropped,
-                            block.quantityDropped(meta, 0, new Random()),
-                            block.damageDropped(meta));
-                }
+        if (block.canSilkHarvest(world.getWorld(), player.getPlayer(), blockPos.x, blockPos.y, blockPos.z, meta)) {
+            stack = BetterBuildersWandsMod.instance.blockCache.getStackedBlock(world, blockPos);
+        } else if (!BetterBuildersWandsMod.instance.configValues.SOFT_BLACKLIST_SET.contains(blockString)) {
+            Item dropped = block.getItemDropped(meta, new Random(), 0);
+            if (dropped != null) {
+                stack = new ItemStack(dropped, block.quantityDropped(meta, 0, new Random()), block.damageDropped(meta));
             }
+        }
         // ForgeEventFactory.fireBlockHarvesting(items,this.world.getWorld(), block, blockPos.x, blockPos.y, blockPos.z,
         // world.getMetadata(blockPos), 0, 1.0F, true, this.player.getPlayer());
         return stack;
     }
 
     private boolean shouldContinue(Point3d currentCandidate, Block targetBlock, int targetMetadata,
-            Block candidateSupportingBlock, int candidateSupportingMeta, AxisAlignedBB blockBB,
-            EnumFluidLock fluidLock) {
+            Block candidateSupportingBlock, int candidateSupportingMeta, AxisAlignedBB blockBB, EnumFluidLock fluidLock,
+            boolean isNBTSensitive, TileEntity targetTile, TileEntity candidateSupportingTile) {
         if (!world.blockIsAir(currentCandidate)) {
             Block currrentCandidateBlock = world.getBlock(currentCandidate);
             if (!(fluidLock == EnumFluidLock.IGNORE && currrentCandidateBlock != null
@@ -111,17 +110,35 @@ public class WandWorker {
                 targetMetadata,
                 new ItemStack(candidateSupportingBlock, 1, candidateSupportingMeta)))
             return false;
-
+        if (isNBTSensitive) {
+            if (targetTile == null || candidateSupportingTile == null) {
+                return false;
+            }
+            NBTTagCompound targetNBT = new NBTTagCompound();
+            NBTTagCompound candidateSupportingNBT = new NBTTagCompound();
+            targetTile.writeToNBT(targetNBT);
+            candidateSupportingTile.writeToNBT(candidateSupportingNBT);
+            targetNBT.removeTag("x");
+            targetNBT.removeTag("y");
+            targetNBT.removeTag("z");
+            candidateSupportingNBT.removeTag("x");
+            candidateSupportingNBT.removeTag("y");
+            candidateSupportingNBT.removeTag("z");
+            if (!targetNBT.equals(candidateSupportingNBT)) {
+                return false;
+            }
+        }
         return !world.entitiesInBox(blockBB);
     }
 
     public LinkedList<Point3d> getBlockPositionList(Point3d blockLookedAt, ForgeDirection placeDirection, int maxBlocks,
-            EnumLock directionLock, EnumLock faceLock, EnumFluidLock fluidLock) {
+            EnumLock directionLock, EnumLock faceLock, EnumFluidLock fluidLock, boolean isNBTSensitive) {
         LinkedList<Point3d> candidates = new LinkedList<Point3d>();
         LinkedList<Point3d> toPlace = new LinkedList<Point3d>();
 
         Block targetBlock = world.getBlock(blockLookedAt);
         int targetMetadata = world.getMetadata(blockLookedAt);
+        TileEntity targetTile = world.getTile(blockLookedAt);
         Point3d startingPoint = blockLookedAt.move(placeDirection);
 
         int directionMaskInt = directionLock.mask;
@@ -141,6 +158,7 @@ public class WandWorker {
             Point3d supportingPoint = currentCandidate.move(placeDirection.getOpposite());
             Block candidateSupportingBlock = world.getBlock(supportingPoint);
             int candidateSupportingMeta = world.getMetadata(supportingPoint);
+            TileEntity candidateSupportingTile = world.getTile(supportingPoint);
             AxisAlignedBB blockBB = targetBlock.getCollisionBoundingBoxFromPool(
                     world.getWorld(),
                     currentCandidate.x,
@@ -153,7 +171,10 @@ public class WandWorker {
                     candidateSupportingBlock,
                     candidateSupportingMeta,
                     blockBB,
-                    fluidLock) && allCandidates.add(currentCandidate)) {
+                    fluidLock,
+                    isNBTSensitive,
+                    targetTile,
+                    candidateSupportingTile) && allCandidates.add(currentCandidate)) {
                 toPlace.add(currentCandidate);
 
                 switch (placeDirection) {
@@ -230,7 +251,12 @@ public class WandWorker {
             CustomMapping mapping = BetterBuildersWandsMod.instance.mappingManager
                     .getMapping(world.getBlock(originalBlock), world.getMetadata(originalBlock));
             if (mapping != null) {
-                blockPlaceSuccess = world.setBlock(blockPos, mapping.getPlaceBlock(), mapping.getPlaceMeta());
+                blockPlaceSuccess = world.setBlock(
+                        originalBlock,
+                        blockPos,
+                        mapping.getPlaceBlock(),
+                        mapping.getPlaceMeta(),
+                        mapping.shouldCopyTileNBT());
             } else {
                 blockPlaceSuccess = world.copyBlock(originalBlock, blockPos);
             }
@@ -242,7 +268,7 @@ public class WandWorker {
                 if (!player.isCreative()) {
                     wand.placeBlock(wandItem, player.getPlayer());
                 }
-                boolean takeFromInventory = player.useItem(sourceItems);
+                boolean takeFromInventory = player.useItem(sourceItems, mapping != null && mapping.shouldCopyTileNBT());
                 if (!takeFromInventory) {
                     FMLLog.info("BBW takeback: %s", blockPos.toString());
                     world.setBlockToAir(blockPos);

--- a/src/main/java/portablejim/bbw/core/conversion/CustomMapping.java
+++ b/src/main/java/portablejim/bbw/core/conversion/CustomMapping.java
@@ -3,6 +3,9 @@ package portablejim.bbw.core.conversion;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
+import portablejim.bbw.basics.Point3d;
+import portablejim.bbw.shims.IWorldShim;
+
 /**
  * Created by james on 18/12/15.
  */
@@ -13,14 +16,21 @@ public class CustomMapping {
     private final ItemStack items;
     private final Block placeBlock;
     private final int placeMeta;
+    private final boolean shouldCopyTileNBT;
 
     public CustomMapping(Block lookBlock, int lookMeta, ItemStack items, Block placeBlock, int placeMeta) {
+        this(lookBlock, lookMeta, items, placeBlock, placeMeta, false);
+    }
+
+    public CustomMapping(Block lookBlock, int lookMeta, ItemStack items, Block placeBlock, int placeMeta,
+            boolean shouldCopyTileNBT) {
 
         this.lookBlock = lookBlock;
         this.meta = lookMeta;
         this.items = items;
         this.placeBlock = placeBlock;
         this.placeMeta = placeMeta;
+        this.shouldCopyTileNBT = shouldCopyTileNBT;
     }
 
     public Block getLookBlock() {
@@ -35,6 +45,10 @@ public class CustomMapping {
         return items;
     }
 
+    public ItemStack getItems(IWorldShim world, Point3d point) {
+        return getItems();
+    }
+
     public Block getPlaceBlock() {
         return placeBlock;
     }
@@ -43,10 +57,15 @@ public class CustomMapping {
         return placeMeta;
     }
 
+    public boolean shouldCopyTileNBT() {
+        return shouldCopyTileNBT;
+    }
+
     public boolean equals(CustomMapping that) {
         return this.lookBlock == that.lookBlock && this.meta == that.meta
                 && this.items == that.items
                 && this.placeBlock == that.placeBlock
-                && this.placeMeta == that.placeMeta;
+                && this.placeMeta == that.placeMeta
+                && this.shouldCopyTileNBT == that.shouldCopyTileNBT;
     }
 }

--- a/src/main/java/portablejim/bbw/core/items/ItemBasicWand.java
+++ b/src/main/java/portablejim/bbw/core/items/ItemBasicWand.java
@@ -22,6 +22,7 @@ import portablejim.bbw.basics.EnumFluidLock;
 import portablejim.bbw.basics.EnumLock;
 import portablejim.bbw.basics.Point3d;
 import portablejim.bbw.core.WandWorker;
+import portablejim.bbw.core.conversion.CustomMapping;
 import portablejim.bbw.core.wands.IWand;
 import portablejim.bbw.shims.BasicPlayerShim;
 import portablejim.bbw.shims.BasicWorldShim;
@@ -70,7 +71,11 @@ public abstract class ItemBasicWand extends Item implements IWandItem {
             ItemStack sourceItems = worker.getProperItemStack(worldShim, playerShim, clickedPos);
 
             if (sourceItems != null && sourceItems.getItem() instanceof ItemBlock) {
-                int numBlocks = Math.min(wand.getMaxBlocks(itemstack), playerShim.countItems(sourceItems));
+                CustomMapping customMapping = BetterBuildersWandsMod.instance.mappingManager
+                        .getMapping(worldShim.getBlock(clickedPos), worldShim.getMetadata(clickedPos));
+                int numBlocks = Math.min(
+                        wand.getMaxBlocks(itemstack),
+                        playerShim.countItems(sourceItems, customMapping != null && customMapping.shouldCopyTileNBT()));
 
                 // FMLLog.info("Max blocks: %d (%d|%d", numBlocks, this.wand.getMaxBlocks(itemstack),
                 // playerShim.countItems(sourceItems));
@@ -80,7 +85,8 @@ public abstract class ItemBasicWand extends Item implements IWandItem {
                         numBlocks,
                         getMode(itemstack),
                         getFaceLock(itemstack),
-                        getFluidMode(itemstack));
+                        getFluidMode(itemstack),
+                        customMapping != null && customMapping.shouldCopyTileNBT());
 
                 ArrayList<Point3d> placedBlocks = worker
                         .placeBlocks(itemstack, blocks, clickedPos, sourceItems, side, hitX, hitY, hitZ);

--- a/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
@@ -60,7 +60,7 @@ public class BasicPlayerShim implements IPlayerShim {
 
         for (ItemStack inventoryStack : player.inventory.mainInventory) {
             if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)
-                    && (ItemStack.areItemStackTagsEqual(itemStack, inventoryStack) || !isNBTSensitive)) {
+                    && (!isNBTSensitive || ItemStack.areItemStackTagsEqual(itemStack, inventoryStack))) {
                 total += Math.max(0, inventoryStack.stackSize);
             } else
                 if (providersEnabled && inventoryStack != null && inventoryStack.getItem() instanceof IBlockProvider) {
@@ -86,7 +86,7 @@ public class BasicPlayerShim implements IPlayerShim {
         for (int i = player.inventory.mainInventory.length - 1; i >= 0; i--) {
             ItemStack inventoryStack = player.inventory.mainInventory[i];
             if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)
-                    && (ItemStack.areItemStackTagsEqual(itemStack, inventoryStack) || !isNBTSensitive)) {
+                    && (!isNBTSensitive || ItemStack.areItemStackTagsEqual(itemStack, inventoryStack))) {
                 if (inventoryStack.stackSize < toUse) {
                     inventoryStack.stackSize = 0;
                     toUse -= inventoryStack.stackSize;

--- a/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
@@ -49,7 +49,7 @@ public class BasicPlayerShim implements IPlayerShim {
     }
 
     @Override
-    public int countItems(ItemStack itemStack) {
+    public int countItems(ItemStack itemStack, boolean isNBTSensitive) {
         int total = 0;
         if (itemStack == null || player.inventory == null || player.inventory.mainInventory == null) {
             return 0;
@@ -59,7 +59,8 @@ public class BasicPlayerShim implements IPlayerShim {
         int meta = getBlockMeta(itemStack);
 
         for (ItemStack inventoryStack : player.inventory.mainInventory) {
-            if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)) {
+            if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)
+                    && (ItemStack.areItemStackTagsEqual(itemStack, inventoryStack) || !isNBTSensitive)) {
                 total += Math.max(0, inventoryStack.stackSize);
             } else
                 if (providersEnabled && inventoryStack != null && inventoryStack.getItem() instanceof IBlockProvider) {
@@ -74,7 +75,7 @@ public class BasicPlayerShim implements IPlayerShim {
     }
 
     @Override
-    public boolean useItem(ItemStack itemStack) {
+    public boolean useItem(ItemStack itemStack, boolean isNBTSensitive) {
         if (itemStack == null || player.inventory == null || player.inventory.mainInventory == null) {
             return false;
         }
@@ -84,7 +85,8 @@ public class BasicPlayerShim implements IPlayerShim {
         List<ItemStack> providers = new ArrayList<ItemStack>();
         for (int i = player.inventory.mainInventory.length - 1; i >= 0; i--) {
             ItemStack inventoryStack = player.inventory.mainInventory[i];
-            if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)) {
+            if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)
+                    && (ItemStack.areItemStackTagsEqual(itemStack, inventoryStack) || !isNBTSensitive)) {
                 if (inventoryStack.stackSize < toUse) {
                     inventoryStack.stackSize = 0;
                     toUse -= inventoryStack.stackSize;

--- a/src/main/java/portablejim/bbw/shims/CreativePlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/CreativePlayerShim.java
@@ -14,12 +14,12 @@ public class CreativePlayerShim extends BasicPlayerShim implements IPlayerShim {
     }
 
     @Override
-    public int countItems(ItemStack itemStack) {
+    public int countItems(ItemStack itemStack, boolean isNBTSensitive) {
         return Integer.MAX_VALUE;
     }
 
     @Override
-    public boolean useItem(ItemStack itemStack) {
+    public boolean useItem(ItemStack itemStack, boolean isNBTSensitive) {
         return true;
     }
 

--- a/src/main/java/portablejim/bbw/shims/IPlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/IPlayerShim.java
@@ -11,9 +11,9 @@ import portablejim.bbw.basics.Point3d;
  */
 public interface IPlayerShim {
 
-    int countItems(ItemStack itemStack);
+    int countItems(ItemStack itemStack, boolean isNBTSensitive);
 
-    boolean useItem(ItemStack itemStack);
+    boolean useItem(ItemStack itemStack, boolean isNBTSensitive);
 
     ItemStack getNextItem(Block block, int meta);
 

--- a/src/main/java/portablejim/bbw/shims/IWorldShim.java
+++ b/src/main/java/portablejim/bbw/shims/IWorldShim.java
@@ -1,6 +1,7 @@
 package portablejim.bbw.shims;
 
 import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
@@ -12,6 +13,8 @@ import portablejim.bbw.basics.Point3d;
 public interface IWorldShim {
 
     Block getBlock(Point3d point);
+
+    TileEntity getTile(Point3d point);
 
     boolean blockIsAir(Point3d point);
 
@@ -27,5 +30,6 @@ public interface IWorldShim {
 
     void playPlaceAtBlock(Point3d position, Block blockType);
 
-    boolean setBlock(Point3d position, Block placeBlock, int placeMeta);
+    boolean setBlock(Point3d originalPosition, Point3d position, Block placeBlock, int placeMeta,
+            boolean shouldCopyNBT);
 }


### PR DESCRIPTION
Added an ArchitectureCraft CustomMapping to BetterBuildersWand to support ArchitectureCraft Blocks with the BuildersWand.
Added check for nbt equality on Tiles for the connection check as well as nbt on the matching item for removing/counting.
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18663