### PR TITLE
Fix crash with AmunRa CollisionLookup

### DIFF
--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -135,24 +135,25 @@ public class WandWorker {
                         || (placeDirection != ForgeDirection.EAST && placeDirection != ForgeDirection.WEST))) {
             candidates.add(startingPoint);
         }
+        AxisAlignedBB blockBB = targetBlock
+                .getCollisionBoundingBoxFromPool(world.getWorld(), blockLookedAt.x, blockLookedAt.y, blockLookedAt.z);
         while (candidates.size() > 0 && toPlace.size() < maxBlocks) {
             Point3d currentCandidate = candidates.removeFirst();
 
             Point3d supportingPoint = currentCandidate.move(placeDirection.getOpposite());
             Block candidateSupportingBlock = world.getBlock(supportingPoint);
             int candidateSupportingMeta = world.getMetadata(supportingPoint);
-            AxisAlignedBB blockBB = targetBlock.getCollisionBoundingBoxFromPool(
-                    world.getWorld(),
-                    currentCandidate.x,
-                    currentCandidate.y,
-                    currentCandidate.z);
+            AxisAlignedBB candidateBB = blockBB.copy().offset(
+                    currentCandidate.x - blockLookedAt.x,
+                    currentCandidate.y - blockLookedAt.y,
+                    currentCandidate.z - blockLookedAt.z);
             if (shouldContinue(
                     currentCandidate,
                     targetBlock,
                     targetMetadata,
                     candidateSupportingBlock,
                     candidateSupportingMeta,
-                    blockBB,
+                    candidateBB,
                     fluidLock) && allCandidates.add(currentCandidate)) {
                 toPlace.add(currentCandidate);
 


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16652
The problem was that AmunRa used it's position to lookup the meta of the block, the queried block was a placement candidate which had a higher meta value in the world than expected.
I changed the code to query the collision hitbox on the targeted block once and then move the hitbox to the candidate position.