### PR TITLE
Grass, Flowers and Bushes can cause a npe when looked at

### DIFF
--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -161,10 +161,13 @@ public class WandWorker {
             Block candidateSupportingBlock = world.getBlock(supportingPoint);
             int candidateSupportingMeta = world.getMetadata(supportingPoint);
             TileEntity candidateSupportingTile = world.getTile(supportingPoint);
-            AxisAlignedBB candidateBB = blockBB.copy().offset(
-                    currentCandidate.x - blockLookedAt.x,
-                    currentCandidate.y - blockLookedAt.y,
-                    currentCandidate.z - blockLookedAt.z);
+            AxisAlignedBB candidateBB = blockBB;
+            if (candidateBB != null) {
+                candidateBB.copy().offset(
+                        currentCandidate.x - blockLookedAt.x,
+                        currentCandidate.y - blockLookedAt.y,
+                        currentCandidate.z - blockLookedAt.z);
+            }
             if (shouldContinue(
                     currentCandidate,
                     targetBlock,

--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -163,7 +163,7 @@ public class WandWorker {
             TileEntity candidateSupportingTile = world.getTile(supportingPoint);
             AxisAlignedBB candidateBB = blockBB;
             if (candidateBB != null) {
-                candidateBB.copy().offset(
+                candidateBB = candidateBB.copy().offset(
                         currentCandidate.x - blockLookedAt.x,
                         currentCandidate.y - blockLookedAt.y,
                         currentCandidate.z - blockLookedAt.z);


### PR DESCRIPTION
When fixing the amun ra crash (#14), I overlooked that BoundingBoxes can be null for all blocks that don't have a collision and then the copy/move fails because of a npe