### PR TITLE
add compat to forestry wood blocks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,4 +7,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:ArchitectureCraft:1.10.2") {
         transitive = false
     }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.1") {
+        transitive = false
+    }
 }

--- a/src/main/java/portablejim/bbw/BetterBuildersWandsMod.java
+++ b/src/main/java/portablejim/bbw/BetterBuildersWandsMod.java
@@ -25,6 +25,7 @@ import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import portablejim.bbw.compat.architecturecraft.ArchitectureCraftCustomMapping;
+import portablejim.bbw.compat.forestrymc.ForestryMCCustomMapping;
 import portablejim.bbw.core.ConfigValues;
 import portablejim.bbw.core.OopsCommand;
 import portablejim.bbw.core.conversion.CustomMappingManager;
@@ -181,6 +182,9 @@ public class BetterBuildersWandsMod {
 
         if (Loader.isModLoaded("ArchitectureCraft")) {
             ArchitectureCraftCustomMapping.register();
+        }
+        if (Loader.isModLoaded("Forestry")) {
+            ForestryMCCustomMapping.register();
         }
     }
 

--- a/src/main/java/portablejim/bbw/compat/architecturecraft/ArchitectureCraftCustomMapping.java
+++ b/src/main/java/portablejim/bbw/compat/architecturecraft/ArchitectureCraftCustomMapping.java
@@ -23,7 +23,7 @@ public class ArchitectureCraftCustomMapping extends CustomMapping {
 
     @Override
     public ItemStack getItems(IWorldShim world, Point3d point) {
-        TileEntity tileEntity = world.getWorld().getTileEntity(point.x, point.y, point.z);
+        TileEntity tileEntity = world.getTile(point);
         if (tileEntity instanceof TileShape) {
             TileShape shapeTile = ((TileShape) tileEntity);
             ItemStack itemStack = shapeTile.newItemStack(1);

--- a/src/main/java/portablejim/bbw/compat/forestrymc/ForestryMCCustomMapping.java
+++ b/src/main/java/portablejim/bbw/compat/forestrymc/ForestryMCCustomMapping.java
@@ -1,0 +1,63 @@
+package portablejim.bbw.compat.forestrymc;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import forestry.arboriculture.blocks.BlockRegistryArboriculture;
+import forestry.arboriculture.tiles.TileWood;
+import forestry.plugins.PluginArboriculture;
+import forestry.plugins.PluginManager;
+import portablejim.bbw.BetterBuildersWandsMod;
+import portablejim.bbw.basics.Point3d;
+import portablejim.bbw.core.conversion.CustomMapping;
+import portablejim.bbw.shims.IWorldShim;
+
+public class ForestryMCCustomMapping extends CustomMapping {
+
+    public ForestryMCCustomMapping(Block lookBlock, int meta) {
+        super(lookBlock, meta, new ItemStack(Item.getItemFromBlock(lookBlock)), lookBlock, meta, true);
+    }
+
+    @Override
+    public ItemStack getItems(IWorldShim world, Point3d point) {
+        TileEntity tileEntity = world.getTile(point);
+        if (tileEntity instanceof TileWood) {
+            return TileWood.getPickBlock(getLookBlock(), world.getWorld(), point.x, point.y, point.z);
+        }
+        return super.getItems(world, point);
+    }
+
+    public static void register() {
+        if (PluginManager.Module.ARBORICULTURE.isEnabled()) {
+            BlockRegistryArboriculture blocks = PluginArboriculture.blocks;
+            registerMappings(blocks.logs, 0, 4, 8);
+            registerMappings(blocks.logsFireproof, 0, 4, 8);
+            registerMappings(blocks.planks, 0);
+            registerMappings(blocks.planks, 0);
+            registerMappings(blocks.slabs, 0, 8);
+            registerMappings(blocks.slabsFireproof, 0, 8);
+            registerMappings(blocks.slabsDouble, 0);
+            registerMappings(blocks.slabsDoubleFireproof, 0);
+            registerMappings(blocks.stairs, range(7));
+            registerMappings(blocks.stairsFireproof, range(7));
+            registerMappings(blocks.fences, 0);
+            registerMappings(blocks.fencesFireproof, 0);
+        }
+    }
+
+    private static void registerMappings(Block block, int... metas) {
+        for (int meta : metas) {
+            BetterBuildersWandsMod.instance.mappingManager.setMapping(new ForestryMCCustomMapping(block, meta));
+        }
+    }
+
+    private static int[] range(int max) {
+        int[] range = new int[max + 1];
+        for (int i = 0; i <= max; i++) {
+            range[i] = i;
+        }
+        return range;
+    }
+}


### PR DESCRIPTION
Add support for forestry wood blocks.
Forestry stores the wood type in nbt on blocks. Uses the same nbt copy behaviour as architecturecraftblocks 
fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18897