### PR TITLE
Restrict build limit

### DIFF
--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -90,6 +90,7 @@ public class WandWorker {
                             || currrentCandidateBlock instanceof BlockLiquid)))
                 return false;
         } ;
+        if (currentCandidate.y >= 255) return false;
         /*
          * if((FluidRegistry.getFluid("water").getBlock().equals(world.getBlock(currentCandidate)) ||
          * FluidRegistry.getFluid("lava").getBlock().equals(world.getBlock(currentCandidate))) &&
@@ -251,7 +252,6 @@ public class WandWorker {
             ItemStack sourceItems, int side, float hitX, float hitY, float hitZ) {
         ArrayList<Point3d> placedBlocks = new ArrayList<Point3d>();
         for (Point3d blockPos : blockPosList) {
-            if ( blockPos.y >= 255 ) continue;
             boolean blockPlaceSuccess;
             CustomMapping mapping = BetterBuildersWandsMod.instance.mappingManager
                     .getMapping(world.getBlock(originalBlock), world.getMetadata(originalBlock));

--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -251,6 +251,7 @@ public class WandWorker {
             ItemStack sourceItems, int side, float hitX, float hitY, float hitZ) {
         ArrayList<Point3d> placedBlocks = new ArrayList<Point3d>();
         for (Point3d blockPos : blockPosList) {
+            if ( blockPos.y >= 255 ) continue;
             boolean blockPlaceSuccess;
             CustomMapping mapping = BetterBuildersWandsMod.instance.mappingManager
                     .getMapping(world.getBlock(originalBlock), world.getMetadata(originalBlock));


### PR DESCRIPTION
Restricts placing blocks above the build limit. Makes builder wand behavior be in line with manual block placing behavior.

See video [here](https://files.jellejurre.dev/ShareX/Jurre/java_jPAI9G7wws.mp4)

The method calls net/minecraft/world/World.java#SetBlock, which has a check for y>=256, but placing blocks and lighting calculations are only possible up and until 0 to 255

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19090