### PR TITLE
Use offhand to decide which block to place

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,4 +10,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.13") {
         transitive = false
     }
+    compileOnly("com.github.GTNewHorizons:Backhand:1.8.2") {
+        transitive = false
+    }
 }

--- a/src/main/java/portablejim/bbw/core/WandWorker.java
+++ b/src/main/java/portablejim/bbw/core/WandWorker.java
@@ -5,9 +5,12 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Random;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -24,6 +27,7 @@ import portablejim.bbw.core.conversion.CustomMapping;
 import portablejim.bbw.core.wands.IWand;
 import portablejim.bbw.shims.IPlayerShim;
 import portablejim.bbw.shims.IWorldShim;
+import xonin.backhand.api.core.BackhandUtils;
 
 /**
  * Does the heavy work of working out the blocks to place and places them.
@@ -43,9 +47,12 @@ public class WandWorker {
         this.world = world;
     }
 
-    public ItemStack getProperItemStack(IWorldShim world, IPlayerShim player, Point3d blockPos) {
-        Block block = world.getBlock(blockPos);
-        int meta = world.getMetadata(blockPos);
+    public @Nullable ItemStack getProperItemStack(IWorldShim world, IPlayerShim player, Point3d blockPos) {
+        ItemStack item = BackhandUtils.getOffhandItem(player.getPlayer());
+        boolean offhand = item != null && item.getItem() instanceof ItemBlock;
+        Block block = offhand ? Block.getBlockFromItem(item.getItem()) : world.getBlock(blockPos);
+        int meta = offhand ? item.getItemDamage() : world.getMetadata(blockPos);
+
         CustomMapping customMapping = BetterBuildersWandsMod.instance.mappingManager.getMapping(block, meta);
         if (customMapping != null) {
             return customMapping.getItems(world, blockPos);
@@ -251,10 +258,14 @@ public class WandWorker {
     public ArrayList<Point3d> placeBlocks(ItemStack wandItem, LinkedList<Point3d> blockPosList, Point3d originalBlock,
             ItemStack sourceItems, int side, float hitX, float hitY, float hitZ) {
         ArrayList<Point3d> placedBlocks = new ArrayList<Point3d>();
+        boolean offhand = !Block.getBlockFromItem(sourceItems.getItem()).equals(world.getBlock(originalBlock));
+        Block block = offhand ? Block.getBlockFromItem(sourceItems.getItem()) : world.getBlock(originalBlock);
+        int meta = offhand ? sourceItems.getItemDamage() : world.getMetadata(originalBlock);
+        CustomMapping mapping = BetterBuildersWandsMod.instance.mappingManager
+                .getMapping(block, meta);
+
         for (Point3d blockPos : blockPosList) {
             boolean blockPlaceSuccess;
-            CustomMapping mapping = BetterBuildersWandsMod.instance.mappingManager
-                    .getMapping(world.getBlock(originalBlock), world.getMetadata(originalBlock));
             if (mapping != null) {
                 blockPlaceSuccess = world.setBlock(
                         originalBlock,
@@ -263,11 +274,15 @@ public class WandWorker {
                         mapping.getPlaceMeta(),
                         mapping.shouldCopyTileNBT());
             } else {
-                blockPlaceSuccess = world.copyBlock(originalBlock, blockPos);
+                blockPlaceSuccess = world.setBlock(
+                        originalBlock,
+                        blockPos,
+                        block,
+                        meta,
+                        false);
             }
 
             if (blockPlaceSuccess) {
-                Block block = world.getBlock(originalBlock);
                 world.playPlaceAtBlock(blockPos, block);
                 placedBlocks.add(blockPos);
                 if (!player.isCreative()) {

--- a/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
+++ b/src/main/java/portablejim/bbw/shims/BasicPlayerShim.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.common.FMLLog;
 import portablejim.bbw.basics.Point3d;
 import vazkii.botania.api.item.IBlockProvider;
 
@@ -18,10 +19,18 @@ public class BasicPlayerShim implements IPlayerShim {
 
     private EntityPlayer player;
     private boolean providersEnabled;
+    private int[] slotPriority;
 
     public BasicPlayerShim(EntityPlayer player) {
         this.player = player;
         this.providersEnabled = areProvidersEnabled();
+        this.slotPriority = new int[player.inventory.mainInventory.length];
+        // Invert so we take first from inventory
+        for (int i = player.inventory.mainInventory.length - 2; i >= 0; i--) {
+            this.slotPriority[i] = i;
+        }
+        // Offhand has lower priority than hotbar
+        this.slotPriority[player.inventory.mainInventory.length - 1] = player.inventory.mainInventory.length - 1;
     }
 
     private static Block getBlock(ItemStack stack) {
@@ -80,10 +89,9 @@ public class BasicPlayerShim implements IPlayerShim {
             return false;
         }
 
-        // Reverse direction to leave hotbar to last.
         int toUse = itemStack.stackSize;
         List<ItemStack> providers = new ArrayList<ItemStack>();
-        for (int i = player.inventory.mainInventory.length - 1; i >= 0; i--) {
+        for (int i : this.slotPriority) {
             ItemStack inventoryStack = player.inventory.mainInventory[i];
             if (inventoryStack != null && itemStack.isItemEqual(inventoryStack)
                     && (!isNBTSensitive || ItemStack.areItemStackTagsEqual(itemStack, inventoryStack))) {
@@ -101,10 +109,11 @@ public class BasicPlayerShim implements IPlayerShim {
                 if (toUse <= 0) {
                     return true;
                 }
-            } else
+            } else {
                 if (providersEnabled && inventoryStack != null && inventoryStack.getItem() instanceof IBlockProvider) {
                     providers.add(inventoryStack);
                 }
+            }
         }
 
         // IBlockProvider does not support removing more than one item in an atomic operation.


### PR DESCRIPTION
This makes wands act like they do in modern versions. So now if the player has an item in the offhand it will try to place that even if it's a different block from the one that the cursor is pointing at.

Also I made it so that the offhand is the slot with least priority when taking blocks from the inventory.